### PR TITLE
Add docs for amb and combineLatest

### DIFF
--- a/src/combiners/amb.ts
+++ b/src/combiners/amb.ts
@@ -13,6 +13,14 @@
 
 import { Observable } from "../types.js";
 
+/**
+ * Takes in multiple observables but only emits items from the first observable
+ * to emit.
+ *
+ * @typeparam T Type of items emitted by the observables.
+ * @param os Observables to race.
+ * @returns Observable that emits items from one of the given observables.
+ */
 export function amb<T>(...os: Array<Observable<T>>): Observable<T> {
   return new ReadableStream({
     async start(controller) {

--- a/src/combiners/combine-latest.ts
+++ b/src/combiners/combine-latest.ts
@@ -15,8 +15,8 @@ import { Observable } from "../types.js";
 
 /**
  * Combines items from multiple observables.
- * The resulting observable emits array tuples
- * whenever any of the given observables emit.
+ * The resulting observable emits array tuples whenever any of the given
+ * observables emit, as long as every observable has emitted at least once.
  * The tuples contain the last emitted item from each observable.
  *
  * @typeparam T Type of items emitted by the observables.

--- a/src/combiners/combine-latest.ts
+++ b/src/combiners/combine-latest.ts
@@ -13,6 +13,16 @@
 
 import { Observable } from "../types.js";
 
+/**
+ * Combines items from multiple observables.
+ * The resulting observable emits array tuples
+ * whenever any of the given observables emit.
+ * The tuples contain the last emitted item from each observable.
+ *
+ * @typeparam T Type of items emitted by the observables.
+ * @param os Observables to combine.
+ * @returns Observable that emits tuples of items.
+ */
 export function combineLatest<T1, T2>(
   o1: Observable<T1>,
   o2: Observable<T2>

--- a/src/sinks/discard.ts
+++ b/src/sinks/discard.ts
@@ -18,7 +18,7 @@
  * @typeparam T Type of items emitted by the observable.
  * @param f Function to call for each value before it’s discarded.
  */
-export function discard<T>(f: (v: T) => unknown = () => {}) {
+export function discard<T>(f: (v: T) => void = () => {}) {
   return new WritableStream<T>({
     write(chunk: T) {
       f(chunk);

--- a/src/transforms/combine-latest-with.ts
+++ b/src/transforms/combine-latest-with.ts
@@ -14,6 +14,17 @@
 import { Transform, Observable } from "../types.js";
 import { combineLatest } from "../combiners/combine-latest.js";
 
+/**
+ * Combines items from the original observable with the other observables.
+ * The resulting `Transform` emits items as array tuples.
+ * whenever the original or any of the given observables emit.
+ * The tuples contain the last emitted item from each observable.
+ *
+ * @typeparam S Type of items emitted by the original observable.
+ * @typeparam T Type of items emitted by `other`.
+ * @param others Other observables to combine with.
+ * @returns Transform that emits tuples of items.
+ */
 export function combineLatestWith<S, T1>(
   other: Observable<T1>
 ): Transform<S, [S, T1]>;

--- a/src/transforms/combine-latest-with.ts
+++ b/src/transforms/combine-latest-with.ts
@@ -16,9 +16,7 @@ import { combineLatest } from "../combiners/combine-latest.js";
 
 /**
  * Combines items from the original observable with the other observables.
- * The resulting `Transform` emits items as array tuples.
- * whenever the original or any of the given observables emit.
- * The tuples contain the last emitted item from each observable.
+ * See {@link combineLatest}.
  *
  * @typeparam S Type of items emitted by the original observable.
  * @typeparam T Type of items emitted by `other`.

--- a/src/transforms/zip-with.ts
+++ b/src/transforms/zip-with.ts
@@ -16,7 +16,7 @@ import { zip } from "../combiners/zip.js";
 
 /**
  * Zips items from the original observable with the `other` observable.
- * The resulting `Transform` emits items as array pairs.
+ * See {@link zip}.
  *
  * @typeparam S Type of items emitted by the original observable.
  * @typeparam T Type of items emitted by `other`.


### PR DESCRIPTION
Adding docs to the last few undocumented functions, based on the Rx docs.

I also changed `discard` so that the [callback type expects `void`](http://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#return-types-of-callbacks).