### PR TITLE
Allow tests to be run in node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 *.pem
 dist
+tmp
 docs
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "fmt": "prettier --write './{src,tests}/**/*.ts' *.{md,json}",
     "build": "tsc -p .",
     "docs": "typedoc --out docs --mode modules",
-    "test": "karma start"
+    "test": "karma start",
+    "pretest:unit": "tsc -p tsconfig.test.json",
+    "test:unit": "mocha --exit tmp/tests/before.js tmp/tests/**/*.js"
   },
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,10 +22,12 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
+    "message-port-polyfill": "^0.2.0",
     "mocha": "^5.2.0",
     "prettier": "^1.15.3",
     "typedoc": "^0.15.2",
-    "typescript": "^3.4.2"
+    "typescript": "^3.4.2",
+    "web-streams-polyfill": "^2.0.6"
   },
   "dependencies": {
     "karma-typescript": "^4.0.0"

--- a/tests/before.ts
+++ b/tests/before.ts
@@ -1,0 +1,9 @@
+import * as chai from 'chai';
+import 'web-streams-polyfill/es2018';
+import { applyPolyfill } from 'message-port-polyfill';
+
+applyPolyfill();
+
+const Mocha = { describe, it };
+// @ts-ignore
+Object.assign(global, { Mocha, chai });

--- a/tests/sources/from-event.ts
+++ b/tests/sources/from-event.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fromEvent, EOF } from "../../src/index.js";
+import { fromEvent } from "../../src/index.js";
 
 Mocha.describe("fromEvent()", function() {
   Mocha.it("emits on events", async function() {

--- a/tests/sources/from-timer.ts
+++ b/tests/sources/from-timer.ts
@@ -21,6 +21,6 @@ Mocha.describe("fromTimer()", function() {
     setTimeout(() => {
       chai.expect(list).to.have.length(4);
       done();
-    }, 40);
+    }, 49);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,6 +58,6 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "exclude": ["tests", "dist"]
+  "exclude": ["tests", "dist", "tmp"]
   // "exclude": ["dist"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "outDir": "./tmp",
+    "module": "commonjs"
   },
-  "exclude": ["dist"]
+  "exclude": ["dist", "tmp"]
 }


### PR DESCRIPTION
Currently a draft because I can't get the timing right with `debounce`.

Adds `web-streams-polyfill` so that the tests can be run locally in Node.js without the need to spin up Chrome.